### PR TITLE
보상 요청 시스템 개선 작업 2 - 사용자 재시도 로직 추가

### DIFF
--- a/src/adapter/input/web/middleware/response.rs
+++ b/src/adapter/input/web/middleware/response.rs
@@ -37,7 +37,6 @@ pub async fn mapper(
 
 	let client_error_message = client_status_error.unzip().1;
 
-	// TODO: Need to hander if log_request fail (but should not fail request)
 	let _ =
 		log_request(uuid, req_method, uri, ctx, service_error, client_error_message.clone().as_ref()).await;
 

--- a/src/adapter/output/persistence/db/error.rs
+++ b/src/adapter/output/persistence/db/error.rs
@@ -32,7 +32,6 @@ impl Error {
             Error::BuildError(message) => (axum::http::StatusCode::INTERNAL_SERVER_ERROR, message.clone()),
         }
     }
-
 }
 
 pub trait PgError {
@@ -44,6 +43,7 @@ impl PgError for diesel::result::Error {
         match self {
             diesel::result::Error::DatabaseError(_, info) => Error::QueryError(info.message().to_string()),
             diesel::result::Error::NotFound => Error::QueryError("Record not found".to_string()),
+            diesel::result::Error::RollbackTransaction => Error::QueryError("Transaction rollback".to_string()),
             _ => Error::QueryError("Unknown query error".to_string()), 
         }
     }

--- a/src/adapter/output/persistence/db/postgres/reward_claim_repository_impl.rs
+++ b/src/adapter/output/persistence/db/postgres/reward_claim_repository_impl.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
+
 use axum::async_trait;
 use deadpool_diesel::postgres::Object;
 use diesel::prelude::*;
 use uuid::Uuid;
-use crate::{adapter::output::persistence::db::schema::reward_claim_detail, domain::model::{reward_claim::{NewRewardClaim, RewardClaim, RewardClaimStatus, ResourceType}, reward_claim_detail::{NewRewardClaimDetail, RewardClaimDetail}}};
+use crate::{adapter::output::persistence::db::schema::reward_claim_detail, domain::model::{reward_claim::{NewRewardClaim, ResourceType, RewardClaim, RewardClaimStatus, UpdateRewardClaimStatus}, reward_claim_detail::{NewRewardClaimDetail, RewardClaimDetail}}};
 use crate::port::output::reward_claim_repository::RewardClaimRepository;
 use super::{Error, Result, adapt_db_error, reward_claim};
 
@@ -53,15 +55,28 @@ impl RewardClaimRepository for PostgresRewardClaimRepository {
     }
 
     async fn list_all_by_user(&self, conn: Object, user_id: Uuid) -> Result<Vec<(RewardClaim, RewardClaimDetail)>> {
-        conn.interact(move |conn| {
+        let result = conn.interact(move |conn| {
             reward_claim::table
                 .filter(reward_claim::user_id.eq(user_id))
                 .inner_join(reward_claim_detail::table)
                 .select((RewardClaim::as_select(), RewardClaimDetail::as_select())) 
                 .load::<(RewardClaim, RewardClaimDetail)>(conn)
         })
-        .await?
-        .map_err(|e| Error::from(adapt_db_error(e)))
+        .await?;
+
+        match result {
+            Ok(claim_details) => {
+                let mut latest_claim_details: HashMap<Uuid, (RewardClaim, RewardClaimDetail)> = HashMap::new();
+                for (claim, detail) in claim_details {
+                    let entry = latest_claim_details.entry(claim.id).or_insert((claim.clone(), detail.clone()));
+                    if detail.created_date > entry.1.created_date {
+                        *entry = (claim, detail);
+                    }
+                }
+                Ok(latest_claim_details.into_iter().map(|(_, v)| v).collect())
+            },
+            Err(e) => Err(Error::from(adapt_db_error(e))),
+        }
     }
 
     async fn update_status(&self, conn: Object, reward_claim_id: Uuid, status: RewardClaimStatus, retryable: bool) -> Result<RewardClaim>{
@@ -81,9 +96,14 @@ impl RewardClaimRepository for PostgresRewardClaimRepository {
                     return Err(diesel::result::Error::RollbackTransaction);
                 }
 
+                let changes = UpdateRewardClaimStatus {
+                    reward_claim_status: status,
+                    updated_date: chrono::Utc::now().naive_utc(),
+                };
+
                 diesel::update(reward_claim::table)
                     .filter(reward_claim::id.eq(target_claim.id))
-                    .set(reward_claim::reward_claim_status.eq(status))
+                    .set(&changes)
                     .returning(RewardClaim::as_select())
                     .get_result::<RewardClaim>(conn)
             })
@@ -247,7 +267,6 @@ mod tests {
         };
 
         let result = repo.insert_detail(db_manager.get_connection().await?, invalid_reward_claim_detail).await;
-        println!("{:?}", result);
         assert!(result.is_err());
 
         Ok(())
@@ -285,7 +304,7 @@ mod tests {
         let inserted_claim_1 = repo.insert(db_manager.get_connection().await?, new_reward_claim_1.clone()).await?;
         let inserted_claim_2 = repo.insert(db_manager.get_connection().await?, new_reward_claim_2.clone()).await?;
 
-        let new_reward_claim_detail_1 = NewRewardClaimDetail {
+        let new_reward_claim_detail_1_1 = NewRewardClaimDetail {
             id: Uuid::new_v4(),
             reward_claim_id: inserted_claim_1.id,
             transaction_hash: "test_hash_1".to_string(),
@@ -293,7 +312,29 @@ mod tests {
             sended_user_address: "sended_address_1".to_string(),
         };
 
-        let new_reward_claim_detail_2 = NewRewardClaimDetail {
+        let new_reward_claim_detail_1_2 = NewRewardClaimDetail {
+            id: Uuid::new_v4(),
+            reward_claim_id: inserted_claim_1.id,
+            transaction_hash: "test_hash_1_2".to_string(),
+            sended_user_id: Uuid::new_v4(),
+            sended_user_address: "sended_address_1".to_string(),
+        };
+
+        let new_reward_claim_detail_2_1 = NewRewardClaimDetail {
+            id: Uuid::new_v4(),
+            reward_claim_id: inserted_claim_2.id,
+            transaction_hash: "test_hash_2".to_string(),
+            sended_user_id: Uuid::new_v4(),
+            sended_user_address: "sended_address_2".to_string(),
+        };
+        let new_reward_claim_detail_2_2 = NewRewardClaimDetail {
+            id: Uuid::new_v4(),
+            reward_claim_id: inserted_claim_2.id,
+            transaction_hash: "test_hash_2".to_string(),
+            sended_user_id: Uuid::new_v4(),
+            sended_user_address: "sended_address_2".to_string(),
+        };
+        let new_reward_claim_detail_2_3 = NewRewardClaimDetail {
             id: Uuid::new_v4(),
             reward_claim_id: inserted_claim_2.id,
             transaction_hash: "test_hash_2".to_string(),
@@ -301,11 +342,24 @@ mod tests {
             sended_user_address: "sended_address_2".to_string(),
         };
 
-        repo.insert_detail(db_manager.get_connection().await?, new_reward_claim_detail_1.clone()).await?;
-        repo.insert_detail(db_manager.get_connection().await?, new_reward_claim_detail_2.clone()).await?;
+        repo.insert_detail(db_manager.get_connection().await?, new_reward_claim_detail_1_1.clone()).await?;
+        repo.insert_detail(db_manager.get_connection().await?, new_reward_claim_detail_1_2.clone()).await?;
+        repo.insert_detail(db_manager.get_connection().await?, new_reward_claim_detail_2_1.clone()).await?;
+        repo.insert_detail(db_manager.get_connection().await?, new_reward_claim_detail_2_2.clone()).await?;
+        repo.insert_detail(db_manager.get_connection().await?, new_reward_claim_detail_2_3.clone()).await?;
 
         let claims = repo.list_all_by_user(db_manager.get_connection().await?, user_id).await?;
         assert_eq!(claims.len(), 2);
+
+        claims.iter().for_each(|(claim, detail)| {
+            if claim.resource_type == ResourceType::Mission {
+                assert_eq!(claim.id, inserted_claim_1.id);
+                assert_eq!(detail.transaction_hash, new_reward_claim_detail_1_2.transaction_hash);
+            } else {
+                assert_eq!(claim.id, inserted_claim_2.id);
+                assert_eq!(detail.transaction_hash, new_reward_claim_detail_2_3.transaction_hash);
+            }
+        });
 
         Ok(())
     }
@@ -331,6 +385,7 @@ mod tests {
         let updated_claim = repo.update_status(db_manager.get_connection().await?, inserted_claim.id, RewardClaimStatus::TransactionApproved, false).await?;
         
         assert_eq!(updated_claim.reward_claim_status, RewardClaimStatus::TransactionApproved);
+        assert_ne!(updated_claim.updated_date, inserted_claim.updated_date);
 
         Ok(())
     }

--- a/src/domain/model/reward_claim.rs
+++ b/src/domain/model/reward_claim.rs
@@ -124,6 +124,13 @@ pub struct NewRewardClaim {
     pub user_address: String,
 }
 
+#[derive(AsChangeset)]
+#[diesel(table_name = reward_claim)]
+pub struct UpdateRewardClaimStatus {
+    pub reward_claim_status: RewardClaimStatus,
+    pub updated_date: NaiveDateTime,
+}
+
 #[derive(Deserialize, Clone, ToSchema)]
 pub struct NewRewardClaimPayload {
     #[schema(value_type = String)]

--- a/src/port/output/reward_claim_repository.rs
+++ b/src/port/output/reward_claim_repository.rs
@@ -18,7 +18,7 @@ pub trait RewardClaimRepository {
 
     async fn list_all_by_user(&self, conn: Object, user_id: Uuid) -> Result<Vec<(RewardClaim, RewardClaimDetail)>>;
     
-    async fn update_status(&self, conn: Object, reward_claim_id: Uuid, status: RewardClaimStatus) -> Result<RewardClaim>;
+    async fn update_status(&self, conn: Object, reward_claim_id: Uuid, status: RewardClaimStatus, retryable: bool) -> Result<RewardClaim>;
     
     // --- reward_claim_detail domain
     async fn insert_detail(&self, conn: Object, new_reward_claim: NewRewardClaimDetail) -> Result<RewardClaimDetail>;

--- a/src/usecase/error.rs
+++ b/src/usecase/error.rs
@@ -79,7 +79,7 @@ impl Error {
             ),
             Self::RewardClaimDuplicate => (
                 StatusCode::CONFLICT,
-                "Mission already claimed".to_string()
+                "Reward already claimed".to_string()
             ),
             Self::TranscationActionVerifyFailed => (
                 StatusCode::BAD_REQUEST,
@@ -122,6 +122,10 @@ impl Error {
                 message.to_string(),
             ),
 
+            Self::AdapterOutputDB(db::Error::QueryError(ref msg)) if msg == "Transaction rollback" => (
+                StatusCode::CONFLICT,
+                "Reward already claimed".to_string()
+            ),
             Self::AdapterOutputDB(error) => error.client_status_and_error(),
             Self::AdapterOutptuNear(error) => error.client_status_and_error(),
 

--- a/tests/concurrency_test.rs
+++ b/tests/concurrency_test.rs
@@ -168,9 +168,9 @@ async fn test_mass_reward() -> Result<()> {
 
 // endregion: --- 동시성 테스트 1
 
-// region: --- 동시성 테스트 2: 악의적인 공격
+// region: --- 동시성 테스트 2: 악의적인 동시 요청
 /**
- *  Total: 1000, 동일 미션에 4명의 유저가 250번씩 악의적인 클레임 요청 
+ *  Total: 1000, 동일 미션에 4명의 유저가 250번씩 동시 클레임 요청 
         Transaction Approved: 4
         Transaction Failed: 0
         Api Error: 996
@@ -211,7 +211,94 @@ async fn test_multi_reward() -> Result<()> {
     Ok(())
 }
 
-// endregion: --- 동시성 테스트 2: 악의적인 공격
+// endregion: --- 동시성 테스트 2: 악의적인 동시 요청
+
+// region: --- 동시성 테스트 3: 악의적인 동시 재요청 
+/**
+ *  1. 한 미션에 여러 유저가 클레임 요청하지만 의도적으로 실패시킴 
+ *  2. 5초 후 실패한 여러 유저들이 동시에 클레임 재요청을 함
+ *      
+ * 1번 시나리오: 4명 유저가 하나의 미션에 각 5번씩 동시 클레임 요청
+ * Total: 20 
+        트랜잭션 재시도 10, 재시도 시간 1초
+            Transaction Approved: 0
+            Transaction Failed: 0
+            Api Error: 20
+        -> 재시도 불가능한 오류이기 때문에 모두 Api Error로 분류됨 
+
+ * Total: 500
+        트랜잭션 재시도 10, 재시도 시간 1초
+            Transaction Approved: 4
+            Transaction Failed: 0
+            Api Error: 496
+ */
+
+#[tokio::test]
+#[ignore]
+async fn test_multi_retry() -> Result<()> {
+    let mut handles: Vec<JoinHandle<Result<String>>> = Vec::new();
+
+    let user_clients = [
+        create_random_user().await?,
+        create_random_user().await?,
+        create_random_user().await?,
+        create_random_user().await?,
+    ];
+
+    // make TRANSACTION_FAILED ExecutionError("Smart contract panicked: Sender and receiver should be different")
+    let len = 20;
+    for i in 0..len {
+        let user_client = &user_clients[i % 4];
+        let hc_clone: Arc<httpc_test::Client> = Arc::clone(&user_client);
+        let handle = tokio::task::spawn_blocking(move || {
+            let mission_id = "a0008dda-0101-d2ff-a12d-b5bf10013811";
+            let coin_network_id = "22222222-0000-0000-0000-000000000001";
+            let user_address = "won999.testnet";
+            
+            tokio::runtime::Handle::current().block_on(create_transcation(hc_clone, &coin_network_id, &mission_id, &user_address))
+        });
+        handles.push(handle);
+    }
+
+    let test_results = Arc::new(TestResults::new());
+    for handle in handles {
+        let result = handle.await??;
+        test_results.record(&result);
+    }
+
+    test_results.print_summary();
+
+    // sleep 5s
+    std::thread::sleep(std::time::Duration::from_secs(5));
+
+    // make RETRY
+    let mut handles2: Vec<JoinHandle<Result<String>>> = Vec::new();
+    let len = 500;
+    for i in 0..len {
+        let user_client = &user_clients[i % 4];
+        let hc_clone: Arc<httpc_test::Client> = Arc::clone(&user_client);
+        let handle2 = tokio::task::spawn_blocking(move || {
+            let mission_id = "a0008dda-0101-d2ff-a12d-b5bf10013811";
+            let coin_network_id = "22222222-0000-0000-0000-000000000001";
+            let user_address = "nomnomnom.testnet";
+            
+            tokio::runtime::Handle::current().block_on(create_transcation(hc_clone, &coin_network_id, &mission_id, &user_address))
+        });
+        handles2.push(handle2);
+    }
+
+    let test_results2 = Arc::new(TestResults::new());
+    for handle2 in handles2 {
+        let result = handle2.await??;
+        test_results2.record(&result);
+    }
+
+    test_results2.print_summary();
+    
+    Ok(())
+}
+
+// endregion: --- 동시성 테스트 3: 악의적인 동시 재요청 
 
 async fn send_reward_claim(hc: Arc<httpc_test::Client>, mission_id: &str) -> Result<String> {
     let response = hc.do_post("/api/reward-claims", json!({
@@ -223,9 +310,27 @@ async fn send_reward_claim(hc: Arc<httpc_test::Client>, mission_id: &str) -> Res
         "user_address": "nomnomnom.testnet"
     })).await?;
 
-    // let _ = response.print().await?;
-
     let body = response.json_body()?;
+    
+    if response.status() != StatusCode::CREATED {
+        return Ok("ApiError".to_string());
+    }
+
+    let tx_status = body["reward_claim_status"].as_str().unwrap();
+
+    Ok(tx_status.to_string())
+}
+
+async fn create_transcation(hc: Arc<httpc_test::Client>, coin_network_id: &str, mission_id: &str, user_address: &str) -> Result<String> {
+    let response = hc.do_post("/api/reward-claims", json!({
+        "resource_id": mission_id,
+        "resource_type": "MISSION",
+        "coin_network_id": coin_network_id,
+        "amount": "0.00001",
+        "user_address": user_address
+    })).await?;
+
+    let body: serde_json::Value = response.json_body()?;
     
     if response.status() != StatusCode::CREATED {
         return Ok("ApiError".to_string());

--- a/tests/concurrency_test.rs
+++ b/tests/concurrency_test.rs
@@ -224,7 +224,7 @@ async fn test_multi_reward() -> Result<()> {
             Transaction Approved: 0
             Transaction Failed: 0
             Api Error: 20
-        -> 재시도 불가능한 오류이기 때문에 모두 Api Error로 분류됨 
+        -> 내부적으로 재시도 불가능한 오류이기 때문에 모두 Api Error로 분류됨 
 
  * Total: 500
         트랜잭션 재시도 10, 재시도 시간 1초

--- a/tests/quick_dev.rs
+++ b/tests/quick_dev.rs
@@ -78,7 +78,7 @@ async fn quick_reward() -> Result<()> {
     })).await?.print().await?;
 
     // reward_claims - mission
-    // 1. failed - mission_sumbit.status = SUBMIT
+    // 1. error - mission_sumbit.status = SUBMIT
     hc.do_post("/api/reward-claims", json!({
         "resource_id": "10000000-0000-0000-0000-000000000001",
         "resource_type": "MISSION",
@@ -106,7 +106,7 @@ async fn quick_reward() -> Result<()> {
     })).await?.print().await?;
 
     // reward_claims - detailed_posting 
-    // 1. failed - detailed_posting.status = CREATE
+    // 1. error - detailed_posting.status = CREATE
     hc.do_post("/api/reward-claims", json!({
         "resource_id": "33333333-0000-0000-0000-000000000001",
         "resource_type": "DETAILED_POSTING",
@@ -124,7 +124,7 @@ async fn quick_reward() -> Result<()> {
         "user_address": "nomnomnom.testnet"
     })).await?.print().await?;
 
-    // 3. failed - detailed_posting.status = CLOSED
+    // 3. error - detailed_posting.status = CLOSED
     hc.do_post("/api/reward-claims", json!({
         "resource_id": "33333333-0000-0000-0000-000000000003",
         "resource_type": "DETAILED_POSTING",


### PR DESCRIPTION
### 작업 내용 
- 트랜잭션 실패시 재시도 기능 추가 
- 데이터 상태 업데이트에 발생하는 동시 처리 이슈 대응 
- 작업 보상 내용 세부 사항 조회 개선 
   - 작업 보상 데이터 - 세부 사항(실패1, 실패2, 성공) 이 있을 때, 작업 보상 데이터 - 세부 사항 (성공)만 매핑하여 API 응답 반환 

### concurrency test 
테스트 시나리오
1. 한 미션에 여러 유저가 클레임 요청하지만 의도적으로 실패시킴 
2. 5초 후 실패한 여러 유저들이 동시에 클레임 재요청을 함

 
```
# 1번 시나리오: 4명 유저가 하나의 미션에 각 5번씩 동시 클레임 요청
Total: 20 
        트랜잭션 재시도 10, 재시도 시간 1초
            Transaction Approved: 0
            Transaction Failed: 0
            Api Error: 20
        -> 내부적으로 재시도 불가능한 오류이기 때문에 모두 Api Error로 분류됨 

# 2번 시나리오: 4명 유저가 해당 미션 실패한 요청에 대해서 총 500회 동시 클레임 재요청
Total: 500
        트랜잭션 재시도 10, 재시도 시간 1초
            Transaction Approved: 4
            Transaction Failed: 0
            Api Error: 496
        -> 4개만 정상적으로 성공 
```