### PR TITLE
feat: Add TLS flag check and update server startup logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@
 # .env.local example (for docker-compose)
 HOST=127.0.0.1
 PORT=8090
+USE_TLS=false
 
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,6 +12,7 @@ use self::near::{KeyRotatingSignerWrapper, NearNetworkConfig};
 struct ServerConfig {
     host: String,
     port: u16,
+    use_tls: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -46,6 +47,10 @@ impl Config {
 
     pub fn server_port(&self) -> u16 {
         self.server.port
+    }
+
+    pub fn server_use_tls(&self) -> bool {
+        self.server.use_tls
     }
 
     pub fn signer(&self) -> KeyRotatingSignerWrapper {
@@ -84,6 +89,7 @@ async fn init_config() -> Config {
             .unwrap_or_else(|_| String::from("8090"))
             .parse::<u16>()
             .unwrap(),
+        use_tls: env::var("USE_TLS").unwrap_or_else(|_| "false".to_string()) == "true",
     };
 
     let db_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<()>{
     let addr = SocketAddr::from((ip_addr, config.server_port()));
     tracing::info!("listening on {}", addr);
 
-    if config.is_local() {
+    if config.is_local() || !config.server_use_tls() {
         axum_server::bind(addr)
         .serve(routes_all.into_make_service())
         .await


### PR DESCRIPTION
### Summary
- Implemented a feature to check the `use_tls` flag during server startup.
- The server now conditionally configures TLS for HTTPS communication based on the `use_tls` flag.

### Changes
- Added logic to check if TLS should be enabled before initializing the server.
- Updated the server startup process to ensure HTTPS is configured correctly when the `use_tls` flag is set to true.

### Questions
I'm planning to write test cases for both HTTP and HTTPS scenarios to ensure the server behaves correctly with and without TLS. What would be the best approach to structure these tests? Any suggestions or best practices are welcome.

### Testing
- Manually tested the server with `use_tls` enabled and disabled to verify proper configuration.
